### PR TITLE
Fixes uri encoding for qrcode generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ const twofactor = require("node-2fa");
 const newSecret = twofactor.generateSecret({ name: "My Awesome App", account: "johndoe" });
 /*
 { secret: 'XDQXYCP5AC6FA32FQXDGJSPBIDYNKK5W',
-  uri: 'otpauth://totp/My Awesome App:johndoe%3Fsecret=XDQXYCP5AC6FA32FQXDGJSPBIDYNKK5W',
-  qr: 'https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=otpauth://totp/My Awesome App:johndoe%3Fsecret=XDQXYCP5AC6FA32FQXDGJSPBIDYNKK5W' 
+  uri: 'otpauth://totp/My%20Awesome%20App:johndoe?secret=XDQXYCP5AC6FA32FQXDGJSPBIDYNKK5W&issuer=My%20Awesome%20App',
+  qr: 'https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=otpauth://totp/My%20Awesome%20App:johndoe%3Fsecret=XDQXYCP5AC6FA32FQXDGJSPBIDYNKK5W%26issuer=My%20Awesome%20App'
 }
 */
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,15 @@ export function generateSecret(options?: Options) {
     .join("")
     .toUpperCase();
 
-  const uri = `otpauth://totp/${config.name}${config.account}%3Fsecret=${secret}`;
+  const query = `?secret=${secret}&issuer=${config.name}`
+  const encodedQuery = query.replace('?', '%3F').replace('&', '%26')
+  const uri = `otpauth://totp/${config.name}${config.account}`
 
-  return { secret, uri, qr: "https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=" + uri };
+  return {
+    secret,
+    uri: `${uri}${query}`,
+    qr: `https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=${uri}${encodedQuery}`
+  };
 }
 
 export function generateToken(secret: string) {


### PR DESCRIPTION
Basically fixes issues mentioned in https://github.com/jeremyscalpello/node-2fa/issues/15

When using the `uri` generated by the current version and passing it through a QR Code generator the scanned QR code is not valid in Google Authenticator. Basically this comes down to the encoding of the `uri` query string indicator (`?`). This PR also adds the `issuer` query string parameter which also helps the authenticator to identify the app. 