### PR TITLE
Typing error with notp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import notp from "notp";
+import * as notp from "notp";
 import crypto from "crypto";
 import b32 from "thirty-two";
 import { Options } from "./interfaces";


### PR DESCRIPTION
When trying to build my code, 
I got `Module '"/path/node_modules/@types/notp/index"' has no default export` from `node_modules/node-2fa/dist/index.d.ts:1:8` 
After changing 
``` TS
import notp from "notp";
```
to 
``` TS
import * as notp from "notp";
```
in index.ts
This error got fixed

;)